### PR TITLE
Initial publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
 [package]
 name = "mariposa"
 version = "0.1.0"
+authors = ["Calvin Figuereo-Supraner <mail@calvin.page>"]
 edition = "2021"
+description = "A chess engine."
+readme = "README.md"
+repository = "https://github.com/clfs/mariposa"
+license = "MIT"
+keywords = ["chess"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# mariposa
+
+A chess engine.


### PR DESCRIPTION
Initial crate for publishing on crates.io.

Dry run publish works:

```text
mariposa % cargo publish --dry-run
    Updating crates.io index
   Packaging mariposa v0.1.0 (/Users/calvin/Developer/repos/mariposa)
   Verifying mariposa v0.1.0 (/Users/calvin/Developer/repos/mariposa)
   Compiling mariposa v0.1.0 (/Users/calvin/Developer/repos/mariposa/target/package/mariposa-0.1.0)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.30s
    Packaged 7 files, 1.4KiB (1008.0B compressed)
   Uploading mariposa v0.1.0 (/Users/calvin/Developer/repos/mariposa)
warning: aborting upload due to dry run
```